### PR TITLE
Fixed s3-deploy.sh script

### DIFF
--- a/s3-publish.sh
+++ b/s3-publish.sh
@@ -9,7 +9,7 @@ else
     . s3.conf
 fi
 
-if [ "$1" == "--help" ]
+if [ ! -z "$1" -a "$1" != "--dry-run" -a "$1" != "-n" ]
 then
     echo "Usage: ./publish.sh [--dry-run|-n]"
     exit 2


### PR DESCRIPTION
There were two problems with `s3-deploy.sh` script:
1. Config file was not loaded so properties from config were always empty.
2. Script was forced to use with `--dry-run` or `-n` arguments. So I was unable to deploy anything :-)

@beryllium as you are creator of this script, can you check my changes as well? Maybe I have misunderstood something.
