### PR TITLE
Add a fenced code block example in sample posts

### DIFF
--- a/source/_posts/2013-02-04-highlight.md
+++ b/source/_posts/2013-02-04-highlight.md
@@ -31,6 +31,9 @@ Here you go!
 
 You can also use [fenced code blocks][fcb] with a syntax declaration at the top.
 The markers are `~` instead of <code>`</code>.
+
+[fcb]: http://michelf.ca/projects/php-markdown/extra/#fenced-code-blocks
+
 ~~~php
 if ($fencedCodeBlock->syntax !== 'PHP') {
     throw new UnexpectedValueException("wat");


### PR DESCRIPTION
The version of PHP markdown used supports fenced code blocks, but
because the marker is atypical (~ instead of `) it's a little more
subtle than Github's rendition.

This change documents that detail in the "highlights" blog post.

Also see: https://github.com/michelf/php-markdown/pull/84
