### PR TITLE
Fix category and tag names in URL which are not URL encoded

### DIFF
--- a/source/_views/post.html
+++ b/source/_views/post.html
@@ -11,7 +11,7 @@
             <p class="categories">
             Categories:
             {% for category in page.categories %}
-            <a href="{{ site.url }}/blog/categories/{{ category }}">{{ category }}</a>{% if not loop.last %}, {% endif %}
+            <a href="{{ site.url }}/blog/categories/{{ category|url_encode(true) }}">{{ category }}</a>{% if not loop.last %}, {% endif %}
             {% endfor %}
             </p>
         {% endif %}
@@ -19,7 +19,7 @@
             <p class="tags">
             Tags:
             {% for tag in page.tags %}
-            <a href="{{ site.url }}/blog/tags/{{ tag }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+            <a href="{{ site.url }}/blog/tags/{{ tag|url_encode(true) }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
             {% endfor %}
             </p>
         {% endif %}

--- a/source/blog/categories.html
+++ b/source/blog/categories.html
@@ -8,6 +8,6 @@ use:
 
 <div>
 {% for category,posts in data.posts_categories %}
-<a href="{{ site.url }}/blog/categories/{{ category }}">{{ category }}</a>
+<a href="{{ site.url }}/blog/categories/{{ category|url_encode(true) }}">{{ category }}</a>
 {% endfor %}
 </div>

--- a/source/blog/tags.html
+++ b/source/blog/tags.html
@@ -8,6 +8,6 @@ use:
 
 <div>
 {% for tag,posts in data.posts_tags %}
-<a href="{{ site.url }}/blog/tags/{{ tag }}">{{ tag }}</a>
+<a href="{{ site.url }}/blog/tags/{{ tag|url_encode(true) }}">{{ tag }}</a>
 {% endfor %}
 </div>

--- a/source/index.html
+++ b/source/index.html
@@ -19,7 +19,7 @@ use:
             <p class="tags">
             Tags:
             {% for tag in post.meta.tags %}
-            <a href="{{ site.url }}/blog/tags/{{ tag }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+            <a href="{{ site.url }}/blog/tags/{{ tag|url_encode(true) }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
             {% endfor %}
             </p>
         {% endif %}


### PR DESCRIPTION
URLs in href should be encoded.

When I use Japanese category/tag names, the output HTML is not good.
