### PR TITLE
Added spaceless filter in all pages

### DIFF
--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{% spaceless %}
 <html>
     <head>
         <title>{% block title %}{{ page.title }}{% endblock %} &mdash; {{ site.title }} &mdash; {{ site.subtitle }}</title>
@@ -86,3 +87,4 @@
         <script>hljs.initHighlightingOnLoad();</script>
     </body>
 </html>
+{% endspaceless %}


### PR DESCRIPTION
Introducing spaceless filter (avilable in twig) reduce the amount of data to sent from server to client, and reduce loading time.

If the site delivery is from AWS or some other system where the amount data transfer must be paid, this can reduce a lot the bandwidth consumption (using my blog for a test approx 60%).

This do not impact on text markup (and code) so it work without problem (need to be test with some other site).