### PR TITLE
Make ATOM feed updated date RFC3339 valid

### DIFF
--- a/source/atom.xml
+++ b/source/atom.xml
@@ -7,7 +7,7 @@ permalink: atom.xml
     <title><![CDATA[{{ site.title }}]]></title>
     <link href="{{ site.url }}/atom.xml" rel="self"/>
     <link href="{{ site.url }}/"/>
-    <updated>{{ site.calculated_date | date('Y-m-d') }}</updated>
+    <updated>{{ site.calculated_date | date('c') }}</updated>
     <id>{{ site.url }}/</id>
     {% if site.author or site.email %}
         <author>


### PR DESCRIPTION
ATOM dates are required to be RFC 3339 compatible in order to pass validation at http://validator.w3.org/feed/
