### PR TITLE
Tweak defaults for sitemap and https

### DIFF
--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -1,3 +1,3 @@
 sculpin_content_types:
     posts:
-        permalink: blog/:year/:month/:day/:filename/
+        permalink: date

--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -3,3 +3,4 @@
 # in a template to get the contents of the `title` key.
 title: Sculpin Blog Skeleton
 subtitle: To Get You Started
+url: http://example.com


### PR DESCRIPTION
Given the sitemap and https issues I noticed with the defaults, I've considered that these changes would simplify and attract attention to values as site.url for the skeleton setup/publishing.
