### PR TITLE
Simple white theme color for a simple white blog skeleton

### DIFF
--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -3,6 +3,7 @@
     <head>
         <title>{% block title %}{{ page.title }}{% endblock %} &mdash; {{ site.title }} &mdash; {{ site.subtitle }}</title>
         <meta charset="utf-8">
+        <meta name="theme-color" content="#ffffff">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="{{ site.url }}/components/bootstrap/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
         <link href="{{ site.url }}/components/bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Simple white theme color for a simple white blog skeleton. Themes Android 5.0 phone browser a bit to your blogs color scheme like seen on my own blog:

![Theme color example](http://i.imgur.com/MqHxZJE.jpg)
