### PR TITLE
Meta tag support

### DIFF
--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -4,6 +4,9 @@
         <title>{% block title %}{{ page.title }}{% endblock %} &mdash; {{ site.title }} &mdash; {{ site.subtitle }}</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        {% block head_meta %}
+            <meta name="robots" content="noindex, follow">
+        {% endblock %}
         <link href="{{ site.url }}/components/bootstrap/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
         <link href="{{ site.url }}/components/bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet" type="text/css" />
         <link href="{{ site.url }}/css/style.css" rel="stylesheet" type="text/css" />
@@ -13,13 +16,14 @@
         <![endif]-->
         <link rel="stylesheet" href="{{ site.url }}/components/highlightjs/styles/github.css" />
         <link rel="alternate" type="application/atom+xml" href="{{ site.url }}/atom.xml" title="{{ site.title }} activity feed" />
-        {% block metaTags %}
-            <meta name="robots" content="noindex, follow">
-        {% endblock %}
         <style>
         /** quick fix because bootstrap <pre> has a background-color. */
         pre code { background-color: inherit; }
         </style>
+        {% block head_styles %}
+        {% endblock %}
+        {% block head_scripts %}
+        {% endblock %}
     </head>
     <body>
         <header>
@@ -87,5 +91,8 @@
         {% endif %}
         <script src="{{ site.url }}/components/highlightjs/highlight.pack.js"></script>
         <script>hljs.initHighlightingOnLoad();</script>
+
+        {% block scripts_after %}
+        {% endblock %}
     </body>
 </html>

--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -13,6 +13,9 @@
         <![endif]-->
         <link rel="stylesheet" href="{{ site.url }}/components/highlightjs/styles/github.css" />
         <link rel="alternate" type="application/atom+xml" href="{{ site.url }}/atom.xml" title="{{ site.title }} activity feed" />
+        {% block metaTags %}
+            <meta name="robots" content="noindex, follow">
+        {% endblock %}
         <style>
         /** quick fix because bootstrap <pre> has a background-color. */
         pre code { background-color: inherit; }

--- a/source/_views/post.html
+++ b/source/_views/post.html
@@ -1,6 +1,6 @@
 {% extends "default" %}
 
-{% block metaTags %}
+{% block head_meta %}
     <meta name="robots" content="index, follow">
 {% endblock %}
 

--- a/source/_views/post.html
+++ b/source/_views/post.html
@@ -1,4 +1,9 @@
 {% extends "default" %}
+
+{% block metaTags %}
+    <meta name="robots" content="index, follow">
+{% endblock %}
+
 {% block content_wrapper %}
     <article>
         <header>

--- a/source/blog/categories/category.html
+++ b/source/blog/categories/category.html
@@ -7,7 +7,7 @@ pagination:
 
 ---
 
-{% block metaTags %}
+{% block head_meta %}
     <link rel="alternate" type="application/atom+xml" href="{{ site.url }}/blog/categories/{{ page.category|url_encode(true) }}.xml" title="{{ site.title }} '{{ page.category }}' category feed" />
     <meta name="robots" content="noindex, follow">
 {% endblock %}

--- a/source/blog/categories/category.html
+++ b/source/blog/categories/category.html
@@ -6,6 +6,12 @@ pagination:
     provider: page.category_posts
 
 ---
+
+{% block metaTags %}
+    <link rel="alternate" type="application/atom+xml" href="{{ site.url }}/blog/categories/{{ page.category|url_encode(true) }}.xml" title="{{ site.title }} '{{ page.category }}' category feed" />
+    <meta name="robots" content="noindex, follow">
+{% endblock %}
+
 {% block title %}{{ page.title }} "{{ page.category }}"{% endblock %}
 {% block content %}
 {% set year = '0' %}

--- a/source/blog/tags/tag.html
+++ b/source/blog/tags/tag.html
@@ -7,7 +7,7 @@ pagination:
 
 ---
 
-{% block metaTags %}
+{% block head_meta %}
     <link rel="alternate" type="application/atom+xml" href="{{ site.url }}/blog/tags/{{ page.tag|url_encode(true) }}.xml" title="{{ site.title }} '{{ page.tag }}' tag feed" />
     <meta name="robots" content="noindex, follow">
 {% endblock %}

--- a/source/blog/tags/tag.html
+++ b/source/blog/tags/tag.html
@@ -6,6 +6,12 @@ pagination:
     provider: page.tag_posts
 
 ---
+
+{% block metaTags %}
+    <link rel="alternate" type="application/atom+xml" href="{{ site.url }}/blog/tags/{{ page.tag|url_encode(true) }}.xml" title="{{ site.title }} '{{ page.tag }}' tag feed" />
+    <meta name="robots" content="noindex, follow">
+{% endblock %}
+
 {% block title %}{{ page.title }} "{{ page.tag }}"{% endblock %}
 {% block content %}
 {% set year = '0' %}


### PR DESCRIPTION
Allow pages to set custom meta tags. The default is not to index anything but allow all links. Only pages with content should be indexed so a site doesn't pollute the search index and might be punished for it. The second thing I've added are feed tags for category and tag feeds added recently.