### PR TITLE
Add base URL to icons in default layout template

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -16,25 +16,25 @@
             <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
         <![endif]-->
 
-        <link rel="apple-touch-startup-image" href="/images/jackson/2048x2048.png">
+        <link rel="apple-touch-startup-image" href="{{ site.url }}/images/jackson/2048x2048.png">
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-capable" content="yes">
-        <link rel="shortcut icon" sizes="76x76" href="/images/jackson/76x76.png">
-        <link rel="shortcut icon" sizes="120x120" href="/images/jackson/120x120.png">
-        <link rel="shortcut icon" sizes="128x128" href="/images/jackson/128x128.png">
-        <link rel="shortcut icon" sizes="152x152" href="/images/jackson/152x152.png">
-        <link rel="shortcut icon" sizes="196x196" href="/images/jackson/196x196.png">
-        <link rel="shortcut icon" sizes="512x512" href="/images/jackson/512x512.png">
-        <link rel="shortcut icon" sizes="1024x1024" href="/images/jackson/1024x1024.png">
-        <link rel="shortcut icon" sizes="2048x2048" href="/images/jackson/2048x2048.png">
-        <link rel="apple-touch-icon" sizes="76x76" href="/images/jackson/76x76.png">
-        <link rel="apple-touch-icon" sizes="120x120" href="/images/jackson/120x120.png">
-        <link rel="apple-touch-icon" sizes="128x128" href="/images/jackson/128x128.png">
-        <link rel="apple-touch-icon" sizes="152x152" href="/images/jackson/152x152.png">
-        <link rel="apple-touch-icon" sizes="196x196" href="/images/jackson/196x196.png">
-        <link rel="apple-touch-icon" sizes="512x512" href="/images/jackson/512x512.png">
-        <link rel="apple-touch-icon" sizes="1024x1024" href="/images/jackson/1024x1024.png">
-        <link rel="apple-touch-icon" sizes="2048x2048" href="/images/jackson/2048x2048.png">
+        <link rel="shortcut icon" sizes="76x76" href="{{ site.url }}/images/jackson/76x76.png">
+        <link rel="shortcut icon" sizes="120x120" href="{{ site.url }}/images/jackson/120x120.png">
+        <link rel="shortcut icon" sizes="128x128" href="{{ site.url }}/images/jackson/128x128.png">
+        <link rel="shortcut icon" sizes="152x152" href="{{ site.url }}/images/jackson/152x152.png">
+        <link rel="shortcut icon" sizes="196x196" href="{{ site.url }}/images/jackson/196x196.png">
+        <link rel="shortcut icon" sizes="512x512" href="{{ site.url }}/images/jackson/512x512.png">
+        <link rel="shortcut icon" sizes="1024x1024" href="{{ site.url }}/images/jackson/1024x1024.png">
+        <link rel="shortcut icon" sizes="2048x2048" href="{{ site.url }}/images/jackson/2048x2048.png">
+        <link rel="apple-touch-icon" sizes="76x76" href="{{ site.url }}/images/jackson/76x76.png">
+        <link rel="apple-touch-icon" sizes="120x120" href="{{ site.url }}/images/jackson/120x120.png">
+        <link rel="apple-touch-icon" sizes="128x128" href="{{ site.url }}/images/jackson/128x128.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="{{ site.url }}/images/jackson/152x152.png">
+        <link rel="apple-touch-icon" sizes="196x196" href="{{ site.url }}/images/jackson/196x196.png">
+        <link rel="apple-touch-icon" sizes="512x512" href="{{ site.url }}/images/jackson/512x512.png">
+        <link rel="apple-touch-icon" sizes="1024x1024" href="{{ site.url }}/images/jackson/1024x1024.png">
+        <link rel="apple-touch-icon" sizes="2048x2048" href="{{ site.url }}/images/jackson/2048x2048.png">
 
         <link rel="stylesheet" href="{{ site.url }}/components/highlightjs/styles/github.css" />
         <link rel="alternate" type="application/atom+xml" href="{{ site.url }}/atom.xml" title="{{ site.title }} activity feed" />


### PR DESCRIPTION
URLs of all icons in default layout template should be prefixed with base site URL.