### PR TITLE
Add vendor dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /output_*/
 /source/components/
 s3.conf
+/vendor/


### PR DESCRIPTION
When you use composer install a lot of not needed files are added to git untracked files