### PR TITLE
Remove type attribute for script tags

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -101,7 +101,7 @@
 
         {% if site.google_analytics_tracking_id %}
 
-        <script type="text/javascript">
+        <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/source/_views/post.html
+++ b/source/_views/post.html
@@ -46,7 +46,7 @@
 
 {% if site.disqus.shortname and site.disqus.shortname != '' %}
 <div id="disqus_thread"></div>
-<script type="text/javascript">
+<script>
     /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
     var disqus_shortname = '{{site.disqus.shortname}}'; // required: replace example with your forum shortname
 


### PR DESCRIPTION
Hello, as noted in the [Mozilla Developer Network docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script), the HTML specification urges authors to omit the type attribute for script tags since it is redundant. In earlier browsers this identified the scripting language of the embedded or imported code.

Thanks for considering merging this or checking it out.