### PR TITLE
Upgrade Bootstrap to 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "sculpin/sculpin": "^2.1@dev",
         "dflydev/embedded-composer": "^1.0@dev",
         "kriswallsmith/assetic": "1.1.2",
-        "components/bootstrap": "^3.3",
+        "components/bootstrap": "^4.1",
         "components/jquery": "^3.1",
         "components/highlightjs": "^9.7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a737a29b6ce692f015b9ef2c7115660c",
+    "content-hash": "d40f2a454f648911a5aea6dc36682c6c",
     "packages": [
         {
             "name": "components/bootstrap",
-            "version": "3.3.7",
+            "version": "4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/components/bootstrap.git",
-                "reference": "fe6e7683be66ba45a725816efdb51d4566733043"
+                "reference": "6c183f17f5d8fbfb38af412c5e0a52135f7d01c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/components/bootstrap/zipball/fe6e7683be66ba45a725816efdb51d4566733043",
-                "reference": "fe6e7683be66ba45a725816efdb51d4566733043",
+                "url": "https://api.github.com/repos/components/bootstrap/zipball/6c183f17f5d8fbfb38af412c5e0a52135f7d01c9",
+                "reference": "6c183f17f5d8fbfb38af412c5e0a52135f7d01c9",
                 "shasum": ""
             },
             "require": {
-                "components/jquery": "1.9.1 - 3"
-            },
-            "suggest": {
-                "components/bootstrap-default": "Provide a theme for Bootstrap as components/bootstrap only provides the CSS as file assets"
+                "components/jquery": ">=2"
             },
             "type": "component",
             "extra": {
@@ -35,10 +32,7 @@
                     "files": [
                         "js/*.js",
                         "css/*.css",
-                        "css/*.map",
-                        "fonts/*",
-                        "less/mixins/*.less",
-                        "less/*.less"
+                        "css/*.map"
                     ],
                     "shim": {
                         "deps": [
@@ -67,12 +61,12 @@
                 "css",
                 "framework",
                 "front-end",
-                "less",
                 "mobile-first",
                 "responsive",
+                "sass",
                 "web"
             ],
-            "time": "2016-07-26T05:59:20+00:00"
+            "time": "2018-05-06T21:06:16+00:00"
         },
         {
             "name": "components/highlightjs",

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -1,19 +1,15 @@
 <!DOCTYPE html>
 <html>
-    <head>
+    <head lang="en">
         <title>{% block title %}{{ page.title }}{% endblock %} &mdash; {{ site.title }} &mdash; {{ site.subtitle }}</title>
         <meta charset="utf-8">
         <meta name="theme-color" content="#ffffff">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         {% block head_meta %}
             <meta name="robots" content="noindex, follow">
         {% endblock %}
         <link href="{{ site.url }}/components/bootstrap/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
         <link href="{{ site.url }}/css/style.css" rel="stylesheet" type="text/css" />
-        <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
-        <!--[if lt IE 9]>
-            <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-        <![endif]-->
 
         <link rel="apple-touch-startup-image" href="{{ site.url }}/images/jackson/2048x2048.png">
         <meta name="mobile-web-app-capable" content="yes">
@@ -37,10 +33,6 @@
 
         <link rel="stylesheet" href="{{ site.url }}/components/highlightjs/styles/github.css" />
         <link rel="alternate" type="application/atom+xml" href="{{ site.url }}/atom.xml" title="{{ site.title }} activity feed" />
-        <style>
-        /** quick fix because bootstrap <pre> has a background-color. */
-        pre code { background-color: inherit; }
-        </style>
         {% block head_styles %}
         {% endblock %}
         {% block head_scripts %}
@@ -48,53 +40,53 @@
     </head>
     <body>
         <header>
-            <nav class="navbar navbar-inverse navbar-fixed-top">
+            <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
                 <div class="container">
-                    <div class="navbar-header">
-                        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-                            <span class="sr-only">Toggle navigation</span>
-                            <span class="icon-bar"></span>
-                            <span class="icon-bar"></span>
-                            <span class="icon-bar"></span>
-                        </button>
-                        <a class="navbar-brand" href="{{ site.url }}/">{{ site.title }}</a>
-                    </div>
-                    <div id="navbar" class="collapse navbar-collapse">
-                        <ul class="nav navbar-nav">
-                            <li><a href="{{ site.url }}/blog">Posts Archive</a></li>
-                            <li><a href="{{ site.url }}/blog/categories">Categories</a></li>
-                            <li><a href="{{ site.url }}/blog/tags">Tags</a></li>
-                            <li><a href="{{ site.url }}/about">About</a></li>
+                    <a class="navbar-brand" href="{{ site.url }}/">{{ site.title }}</a>
+                    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarCollapse">
+                        <ul class="navbar-nav mr-auto">
+                            <li class="nav-item"><a class="nav-link" href="{{ site.url }}/blog">Posts Archive</a></li>
+                            <li class="nav-item"><a class="nav-link" href="{{ site.url }}/blog/categories">Categories</a></li>
+                            <li class="nav-item"><a class="nav-link" href="{{ site.url }}/blog/tags">Tags</a></li>
+                            <li class="nav-item"><a class="nav-link" href="{{ site.url }}/about">About</a></li>
                         </ul>
                     </div>
                 </div>
             </nav>
         </header>
-        <div class="mainContent container">
-            <div class="row-fluid">
-                <div class="span8">
+        <main role="main" class="container">
+            <div class="row">
+                <div class="col-sm-8">
                     {% block content_wrapper %}{% block content %}{% endblock %}{% endblock %}
                 </div>
-                <div class="span4 sidebar">
-                    <div class="well">
-                        <h4>{{ site.title }}{% if site.subtitle %} <small>{{ site.subtitle }}</small>{% endif %}</h4>
+                <div class="col-sm-4 sidebar">
+                    <div class="card bg-light">
+                        <div class="card-header">{{ site.title }}</div>
+                        <div class="card-body">
+                            {% if site.subtitle %}<small>{{ site.subtitle }}</small>{% endif %}
+                        </div>
                     </div>
-                    <div class="well sidebar-nav">
-                        <h4>Links</h4>
-                        <ul class="nav">
-                            <li><a href="http://sculpin.io">sculpin.io</a></li>
-                            <li><a href="http://twitter.com/getsculpin">@getsculpin</a></li>
-                        </ul>
+                    <div class="card bg-light sidebar-nav">
+                        <div class="card-header">Links</div>
+                        <div class="card-body">
+                            <ul class="nav flex-column">
+                                <li class="nav-item"><a class="nav-link" href="http://sculpin.io">sculpin.io</a></li>
+                                <li class="nav-item"><a class="nav-link" href="http://twitter.com/getsculpin">@getsculpin</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        </main>
         <footer class="container">
-            &copy; {{ "now"|date("Y") }} {{ site.title }}
+            <span class="text-muted">&copy; {{ "now"|date("Y") }} {{ site.title }}</span>
         </footer>
 
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-        <script>window.jQuery || document.write('<script src="{{ site.url }}/components/jquery/jquery.min.js"><\/script>')</script>
+        <script src="{{ site.url }}/components/jquery/jquery.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"></script>
         <script src="{{ site.url }}/components/bootstrap/js/bootstrap.min.js"></script>
         {% block scripts %}
         {% endblock %}

--- a/source/css/style.css
+++ b/source/css/style.css
@@ -1,11 +1,9 @@
-h4 small
-{
+small {
     display: block;
-    font-size: 60%;
     color: #888;
 }
 
-.mainContent, footer.container {
+main.container, footer.container {
     max-width: 900px;
 }
 
@@ -20,9 +18,13 @@ footer.container {
         padding-top: 30px;
     }
 }
+
 @media (min-width: 980px) {
     body {
-        padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
         padding-bottom: 40px;
     }
+}
+
+body > main.container {
+    padding: 80px 15px 0; /* 80px to make the container go all the way to the bottom of the topbar */
 }


### PR DESCRIPTION
Hello, as suggested in #56 this patch upgrades the Bootstrap v3 to v4.

## Bootstrap 3 layout
![bootstrap3](https://user-images.githubusercontent.com/1614009/39963262-241fd8aa-5667-11e8-97fc-da37846e7a2f.png)

## Bootstrap 4 layout
![bootstrap4](https://user-images.githubusercontent.com/1614009/39963263-2b884c08-5667-11e8-9ee1-a976122a6df3.png)

## Changes

* composer.json and composer.lock upgraded with only `components/bootstrap` package
* Default main layout Twig template adjusted for new Bootstrap 4
* Default main layout updated a bit (some CSS patches are not needed anymore, and some new ones are needed).
* CSS slightly adjusted for small and large screeens
* Everything else is the same as before and left to the default Bootstrap's CSS
* This patch also fixes #48 

In case there needs to be changed something else in this pull request directly, let me know. Thanks for considering merging this or checking this out.