### PR TITLE
anything beyond the most basic introduction should be in the documentation to avoid redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,32 +25,46 @@ A very basic Sculpin based blog supporting the following features:
  * A blog tag index at `/blog/tags/$tag`. Similar to the blog archive
    except broken down by each tag.
 
+Prerequisites
+-------------
+
+Sculpin is a PHP application and installed with the PHP package manager `composer`.
+See https://getcomposer.org/ for installation instructions.
+
+Unless you do a very basic website, you want some CSS and Javascript assets. Sculpin
+uses `yarn` to manage them. See https://yarnpkg.com/en/docs/install for installation
+instructions.
+
 Install
 -------
 
-This application uses [Symfony's Webpack Encore](https://symfony.com/doc/current/frontend.html)
-to manage CSS, JavaScript and image assets. First install the JS dependencies:
+Create a new project using composer:
 
 ```bash
-$ yarn install
+$ composer create-project -s dev sculpin/blog-skeleton my-blog
 ```
 
-Then install the PHP dependencies (Sculpin):
+This application uses [Symfony's Webpack Encore](https://symfony.com/doc/current/frontend.html)
+to manage CSS, JavaScript and image assets. Install the JS dependencies:
 
 ```bash
-$ composer install
+$ cd my-blog
+$ yarn install
 ```
 
 Build
 -----
 
-First run Encore, to compile the assets in `source/assets/` into `source/build/`:
+Run Encore to compile the assets from `source/assets/` into `source/build/`:
 
 ```bash
 $ yarn encore dev --watch
 ```
 
-Then generate the site with Sculpin:
+With the `--watch` option, yarn will keep running and update the assets
+whenever you change a source asset.
+
+Then create a new console window and generate and serve the site with Sculpin:
 
 ```bash
 $ php vendor/bin/sculpin generate --watch --server
@@ -59,77 +73,12 @@ $ php vendor/bin/sculpin generate --watch --server
 Your newly generated clone of sculpin-blog-skeleton is now
 accessible at `http://localhost:8000/`.
 
+With the `--watch` option, sculpin will keep running and update the HTML
+whenever you change a source document.
 
-Previewing Development Builds
------------------------------
+Documentation
+-------------
 
-By default the site will be generated in `output_dev/`. This is the location
-of your development build.
-
-To preview it with Sculpin's built in webserver, run either of the following
-commands. This will start a simple webserver listening at `localhost:8000`.
-
-### Using Sculpin's Internal Webserver
-
-#### Generate Command
-
-To serve files right after generating them, use the `generate` command with
-the `--server` option:
-
-    php vendor/bin/sculpin generate --server
-
-To listen on a different port, specify the `--port` option:
-
-    php vendor/bin/sculpin generate --server --port=9999
-
-Combine with `--watch` to have Sculpin pick up changes as you make them:
-
-    php vendor/bin/sculpin generate --server --watch
-
-
-##### Server Command
-
-To serve files that have already been generated, use the `serve` command:
-
-    php vendor/bin/sculpin serve
-
-To listen on a different port, specify the `--port` option:
-
-    php vendor/bin/sculpin serve --port=9999
-
-
-### Using a Standard Webserver
-
-The only special consideration that needs to be taken into account for standard
-webservers **in development** is the fact that the URLs generated may not match
-the path at which the site is installed.
-
-This can be solved by overriding the `site.url` configuration option when
-generating the site.
-
-    sculpin generate --url=http://my.dev.host/blog-skeleton/output_dev
-
-With this option passed, `{{ site.url }}/about` will now be generated as
-`http://my.dev.host/blog-skelton/output_dev/about` instead of `/about`.
-
-
-Publishing Production Builds
-----------------------------
-
-When `--env=prod` is specified, the site will be generated in `output_prod/`. This
-is the location of your production build.
-
-    php vendor/bin/sculpin generate --env=prod
-
-These files are suitable to be transferred directly to a production host. For example:
-
-    php vendor/bin/sculpin generate --env=prod
-    rsync -avze 'ssh -p 999' output_prod/ user@yoursculpinsite.com:public_html
-
-If you want to make sure that rsync deletes files that you deleted locally on the on the remote too, add the `--delete` option to the rsync command:
-
-    rsync -avze 'ssh -p 999' --delete output_prod/ user@yoursculpinsite.com:public_html
-
-In fact, `publish.sh` is provided to get you started. If you plan on deploying to an
-Amazon S3 bucket, you can use `s3-publish.sh` alongside the `s3cmd` utility (must be
-installed separately).
+The skeleton provides you with useful configuration and some example data for
+a Sculpin installation. Check out the [Get Started page](https://sculpin.io/getstarted/)
+and have a look at the [documentation](https://sculpin.io/documentation/).


### PR DESCRIPTION
fix #47 