### PR TITLE
Remove path from command.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         ],
         "sculpin-watch": [
             "Composer\\Config::disableProcessTimeout",
-            "./vendor/bin/sculpin generate --watch --server"
+            "sculpin generate --watch --server"
         ],
         "yarn-watch": [
             "Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
Including the ./vendor/bin path in the sculpin-watch command prevents the command from being run successfully on windows. 

	w:\sculpin>composer sculpin-watch
	> Composer\Config::disableProcessTimeout
	> ./vendor/bin/sculpin generate --watch --server
	'.' is not recognized as an internal or external command,
	operable program or batch file.
	Script ./vendor/bin/sculpin generate --watch --server handling the sculpin-watch event returned with error code 1

The path is not necessary as [composer adds the bin directory to PATH](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands) before running commands.  

Removing the path from the command definition then resolves the issue and allows the command to be run successfully on windows.

	W:\sculpin>composer sculpin-watch
	> Composer\Config::disableProcessTimeout
	> sculpin generate --watch --server
	Detected new or updated files
	Generating: 100% (43 sources / 0.00 seconds)
	Converting: 100% (73 sources / 0.47 seconds)
	Formatting: 100% (73 sources / 0.04 seconds)
	Processing completed in 0.72 seconds
	Starting Sculpin server for the dev environment with debug true
	Development server is running at http://localhost:8000
	Quit the server with CONTROL-C.
