### PR TITLE
Use webpack manifest for asset paths.

### DIFF
--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -1,3 +1,6 @@
+sculpin_twig:
+    webpack_manifest: build/manifest.json
+
 sculpin_content_types:
     posts:
         permalink: blog/:year/:month/:day/:filename/

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -8,7 +8,7 @@
         {% block head_meta %}
             <meta name="robots" content="noindex, follow">
         {% endblock %}
-        <link rel="stylesheet" href="{{ site.url }}/build/app.css">
+        <link rel="stylesheet" href="{{ site.url }}{{ webpack_manifest['build/app.css']}}" />
 
         <link rel="apple-touch-startup-image" href="{{ site.url }}/build/2048x2048.png">
         <meta name="mobile-web-app-capable" content="yes">
@@ -83,7 +83,7 @@
             <span class="text-muted">&copy; {{ "now"|date("Y") }} {{ site.title }}</span>
         </footer>
 
-        <script src="{{ site.url }}/build/app.js"></script>
+        <script type="text/javascript" src="{{ site.url }}{{ webpack_manifest['build/app.js']}}"></script>
         {% block scripts %}
         {% endblock %}
 


### PR DESCRIPTION
Changes asset build path to use webpack manifest file by default.

I originally came across this as I had issues with cache busting on my host, and noticed the default view was always loading app.js instead of app.{hash}.js